### PR TITLE
Fixes #2: Domain sync not accounting for "Sync Next Due Date" setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Synergy Wholesale WHMCS Domains Module
 ### Removed
 -
 
+## 2.0.2 [Updated 18/02/2020]
+### Fixed
+- Fixed "Next Due Date" not accounting for `Sync Next Due Date` setting on domain sync. Fixes [#1](https://github.com/SynergyWholesale/WHMCS-Domains-Module/issues/2)
+
 ## 2.0.1 [Updated 07/02/2020]
 ### Fixed
 - Fixed support for PHP 7.2 and below. Fixes [#1](https://github.com/SynergyWholesale/WHMCS-Domains-Module/issues/1)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Synergy Wholesale WHMCS Domains Module
 -
 
 ## 2.0.2 [Updated 18/02/2020]
+### Changed
+- PHP Version sent in API requests no longer include the `[extra]` version details
+
 ### Fixed
 - Fixed "Next Due Date" not accounting for `Sync Next Due Date` setting on domain sync. Fixes [#1](https://github.com/SynergyWholesale/WHMCS-Domains-Module/issues/2)
 

--- a/modules/registrars/synergywholesaledomains/synergywholesaledomains.php
+++ b/modules/registrars/synergywholesaledomains/synergywholesaledomains.php
@@ -83,7 +83,7 @@ function synergywholesaledomains_apiRequest($command, array $params = [], array 
      * backwards compatability across WHMCS versions and PHP support.
      */
     $analytics = [
-        'php_ver' => phpversion(),
+        'php_ver' => str_replace(PHP_EXTRA_VERSION, '', PHP_VERSION),
         'whmcs_ver' => $params['whmcsVersion'],
         'whmcs_mod_ver' => SW_MODULE_VERSION,
     ];

--- a/modules/registrars/synergywholesaledomains/synergywholesaledomains.php
+++ b/modules/registrars/synergywholesaledomains/synergywholesaledomains.php
@@ -2250,6 +2250,8 @@ function synergywholesaledomains_sync_adhoc(array $params)
  */
 function synergywholesaledomains_adhocTransferSync(array $params, $domainInfo)
 {
+    global $_LANG, $CONFIG;
+
     $response = synergywholesaledomains_TransferSync($params);
     $update = $syncMessages = [];
     if (isset($response['error'])) {
@@ -2270,11 +2272,11 @@ function synergywholesaledomains_adhocTransferSync(array $params, $domainInfo)
         if ($response['expirydate']) {
             $newBillDate = $update['expirydate'] = $response['expirydate'];
             if ($CONFIG['DomainSyncNextDueDate'] && $CONFIG['DomainSyncNextDueDateDays']) {
-                $timeCalculation = strtotime($response['expirydate']) - strtotime($CONFIG['DomainSyncNextDueDateDays'] . ' days');
-                $newBillDate = date('Y-m-d', $timeCalculation);
+                $unix_expiry = strtotime($response['expirydate']);
+                $newBillDate = date('Y-m-d', strtotime(sprintf('-%d days', $CONFIG['DomainSyncNextDueDateDays']), $unix_expiry));
             }
 
-            $update['nextinvoicedate'] =  $update['nextduedate'] = $newBillDate;
+            $update['nextinvoicedate'] = $update['nextduedate'] = $newBillDate;
         }
     }
 
@@ -2354,6 +2356,8 @@ function synergywholesaledomains_adhocTransferSync(array $params, $domainInfo)
  */
 function synergywholesaledomains_adhocSync(array $params, $domainInfo)
 {
+    global $CONFIG;
+
     $response = synergywholesaledomains_Sync($params);
     $syncMessages = $update = [];
     if (isset($response['error'])) {
@@ -2391,8 +2395,8 @@ function synergywholesaledomains_adhocSync(array $params, $domainInfo)
     if ($response['expirydate']) {
         $newBillDate = $update['expirydate'] = $response['expirydate'];
         if ($CONFIG['DomainSyncNextDueDate'] && $CONFIG['DomainSyncNextDueDateDays']) {
-            $timeCalculation = strtotime($response['expirydate']) - strtotime($CONFIG['DomainSyncNextDueDateDays'] . ' days');
-            $newBillDate = date('Y-m-d', $timeCalculation);
+            $unix_expiry = strtotime($response['expirydate']);
+            $newBillDate = date('Y-m-d', strtotime(sprintf('-%d days', $CONFIG['DomainSyncNextDueDateDays']), $unix_expiry));
         }
 
         if ($newBillDate != $domainInfo->nextinvoicedate) {


### PR DESCRIPTION
I've addressed the bug report about the domain sync not accounting for the "Sync Next Due Date" setting.

I've also updated the PHP version parameter in our analytics to strip the `[extra]` component of the version.