### PR TITLE
Fixed #21: Updating technical contacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Synergy Wholesale WHMCS Domains Module
 ### Removed
 -
 
+
+## 2.1.7 [Updated 26/05/2020]
+### Fixed
+- Fixed an issue with updating technical contacts. Fixes [#21](https://github.com/SynergyWholesale/WHMCS-Domains-Module/issues/21)
+
 ## 2.1.6 [Updated 14/05/2020]
 
 ### Fixed

--- a/modules/registrars/synergywholesaledomains/synergywholesaledomains.php
+++ b/modules/registrars/synergywholesaledomains/synergywholesaledomains.php
@@ -1028,7 +1028,7 @@ function synergywholesaledomains_SaveContactDetails(array $params)
     $contactTypes = [
         'registrant' => 'Registrant', 
         'admin' => 'Admin',
-        'tech' => 'Technical',
+        'technical' => 'Tech',
         'billing' => 'Billing',
     ];
     

--- a/modules/registrars/synergywholesaledomains/synergywholesaledomains.php
+++ b/modules/registrars/synergywholesaledomains/synergywholesaledomains.php
@@ -1025,9 +1025,14 @@ function synergywholesaledomains_TransferSync(array $params)
 function synergywholesaledomains_SaveContactDetails(array $params)
 {
     $request = [];
-
-    foreach (['registrant', 'admin', 'tech', 'billing'] as $contactType) {
-        $whmcs_contact = ucfirst($contactType);
+    $contactTypes = [
+        'registrant' => 'Registrant', 
+        'admin' => 'Admin',
+        'tech' => 'Technical',
+        'billing' => 'Billing',
+    ];
+    
+    foreach ($contactTypes as $contactType => $whmcs_contact) {
         if (!isset($params['contactdetails'][$whmcs_contact])) {
             continue;
         }

--- a/modules/registrars/synergywholesaledomains/synergywholesaledomains.php
+++ b/modules/registrars/synergywholesaledomains/synergywholesaledomains.php
@@ -1031,7 +1031,7 @@ function synergywholesaledomains_SaveContactDetails(array $params)
         'technical' => 'Tech',
         'billing' => 'Billing',
     ];
-    
+
     foreach ($contactTypes as $contactType => $whmcs_contact) {
         if (!isset($params['contactdetails'][$whmcs_contact])) {
             continue;
@@ -1046,8 +1046,6 @@ function synergywholesaledomains_SaveContactDetails(array $params)
             $params['contactdetails'][$whmcs_contact]['Address 3'],
         ];
 
-        $request["{$contactType}_address"] = array_filter($request["{$contactType}_address"]);
-
         $request["{$contactType}_email"] = $params['contactdetails'][$whmcs_contact]['Email'];
         $request["{$contactType}_suburb"] = $params['contactdetails'][$whmcs_contact]['City'];
         $request["{$contactType}_postcode"] = $params['contactdetails'][$whmcs_contact]['Postcode'];
@@ -1061,10 +1059,10 @@ function synergywholesaledomains_SaveContactDetails(array $params)
 
         $request["{$contactType}_country"] = $params['contactdetails'][$whmcs_contact]['Country'];
         // See if country is AU
-        if ('AU' == $country) {
+        if ('AU' == $request["{$contactType}_country"]) {
             // It is, so check to see if a valid AU State has been specified
             $state = synergywholesaledomains_validateAUState($params['contactdetails'][$whmcs_contact]['State']);
-            if (!$state) {
+            if (!empty($params['contactdetails'][$whmcs_contact]['State']) && !$state) {
                 return [
                     'error' => 'A Valid Australian State Name Must Be Supplied, EG. NSW, VIC',
                 ];


### PR DESCRIPTION
It looks like the WHMCS technical contact is referred to as the `Technical` and not the `Tech` contact. I've fixed this and updated our loop so it's clearer how the SW API parameters map to the relevant WHMCS parameters.

### Fixed
- Fixed an issue with updating technical contacts. Fixes [#21](https://github.com/SynergyWholesale/WHMCS-Domains-Module/issues/21)