### PR TITLE
Fixed incorrect transfer domain conditions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Synergy Wholesale WHMCS Domains Module
 ### Removed
 -
 
+## 2.1.10 [Updated 09/10/2020]
+### Fixed
+- Fixed transfer domain conditions incorrectly testing against the SLD and not the TLD.
+
 ## 2.1.9 [Updated 25/08/2020]
 ### Fixed
 - Fixed internal transfers not being renewed upon transfer-in. Fixes [#33](https://github.com/SynergyWholesale/WHMCS-Domains-Module/issues/33)

--- a/modules/registrars/synergywholesaledomains/synergywholesaledomains.php
+++ b/modules/registrars/synergywholesaledomains/synergywholesaledomains.php
@@ -632,7 +632,7 @@ function synergywholesaledomains_RegisterDomain(array $params)
  */
 function synergywholesaledomains_TransferDomain(array $params)
 {
-    if (preg_match('/\.uk$/', $params['sld'])) {
+    if (preg_match('/\.uk$/', $params['tld'])) {
         return synergywholesaledomains_apiRequest('transferDomain', $params);
     }
 
@@ -641,7 +641,7 @@ function synergywholesaledomains_TransferDomain(array $params)
         'doRenewal' => 1,
     ];
 
-    if (preg_match('/\.au$/', $params['sld'])) {
+    if (preg_match('/\.au$/', $params['tld'])) {
         $canRenew = synergywholesaledomains_apiRequest('domainRenewRequired', $params, $request, false);
         $request['doRenewal'] = (int) ('on' === $params['doRenewal'] && 'OK_RENEWAL' === $canRenew['status']);
     }


### PR DESCRIPTION
Someone with an eagle eye noticed that our domain transfer conditions were using the `sld` instead of the `tld`. This PR addresses that issue.