### PR TITLE
fix: remove tests from build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,6 @@ package:
 	make revert
 
 build:
-	make test
 	make build-assets
 	make update-whois
 	make replace


### PR DESCRIPTION
due to the fact this runs without php being setup, the composer install fails on the ubuntu runner container causing builds to fail