### PR TITLE
Fixing issue with Synergy API not matching the API documentation

### DIFF
--- a/modules/registrars/synergywholesaledomains/synergywholesaledomains.php
+++ b/modules/registrars/synergywholesaledomains/synergywholesaledomains.php
@@ -996,7 +996,19 @@ function synergywholesaledomains_TransferSync(array $params)
         ];
     }
 
+    // We can't JUST check domain_status, as it ONLY appears to exist on completed domains. 
+    // (Synergy API does NOT match their API Doc. Opened a support case asking for clarification, but was told 'A ticket has been created, but it has not had time allocated, we don't know when we will give you an answer on why they don't match.'   Yeah, thanks.
+    // We'll just have to modify this to handle what we ARE getting back.
     if (!isset($response['domain_status'])) {
+        if (isset($response['transfer_status']) && isset($response['status']) &&
+            in_array($response['status'], ['OK_TRANSFER_TIMEOUT', 'OK_TRANSFER_REJECTED', 'OK_TRANSFER_CANCELLED'])) {
+           // It  has timed out, was cancelled, or was rejected)
+           return [
+               'completed' => false,
+               'failed' => true,
+               'reason' => 'Transfer was either rejected, cancelled or timed out'
+            ];
+        }
         return [
             'completed' => false,
         ];


### PR DESCRIPTION
Synergy WHMCS module does not send Transfer Timeout/Cancelled/Rejected emails due to a disparity between the API and the API Documentation/WHMCS Module.  The below patch allows the Synergy module to start sending transfer timeout emails as expected again.  Ref ticket SYN-C4788649