### PR TITLE
fixes data import bug when seeding domain list from sql

### DIFF
--- a/modules/registrars/synergywholesaledomains/synergywholesaledomains.php
+++ b/modules/registrars/synergywholesaledomains/synergywholesaledomains.php
@@ -941,11 +941,13 @@ function synergywholesaledomains_Sync(array $params)
                     }
                 }
                 Capsule::table('tbldomainsadditionalfields')
-                    ->where('domainid', $params['domainid'])
-                    ->where('name', $whmcsName)
-                    ->update([
-                        'value' => $response[$apiName],
-                    ]);
+                    ->updateOrInsert(
+                        [
+                            'domainid' => $params['domainid'],
+                            'name' => $whmcsName
+                        ],
+                        ['value' => $response[$apiName]]
+                    );
             }
         } catch (\Exception $e) {
             logModuleCall('synergywholesaledomains', 'sync_process', 'Update DB', $e->getMessage());


### PR DESCRIPTION
I imported a bunch of .au domains via SQL with the Pending Transfer status, and the sync did not pull all of the eligibility data in from the API and store it locally, as the rows did not exist in `tbldomainsadditionalfields`. Editing each domain in whmcs created them and they worked - but that was too slow.

updateOrInsert seems to be the better way to deal with this here - as it doesn't matter how the domain is added to WHMCS  now :-)