### PR TITLE
Failed CoR -> Module Queue; Tax Invoice w/ Year/s

### DIFF
--- a/modules/registrars/synergywholesaledomains/synergywholesaledomains.php
+++ b/modules/registrars/synergywholesaledomains/synergywholesaledomains.php
@@ -10,6 +10,7 @@
 use Illuminate\Database\Capsule\Manager as Capsule;
 use Carbon\Carbon;
 use Illuminate\Support\Str;
+use WHMCS\Module\Queue;
 
 define('API_ENDPOINT', 'https://{{API}}');
 define('WHATS_MY_IP_URL', 'https://{{FRONTEND}}/ip');
@@ -2542,13 +2543,13 @@ function synergywholesaledomains_initiateAuCor(array $params)
             'domainName' => $domainInfo->domain ?? '',
         ], true);
     } catch (Exception $e) {
-        // Create item in Module Queue and then fail gracefully (as well)
-        WHMCS\Module\Queue::add(
+        // Create item in Module Queue
+        Queue::add(
             'domain',  // serviceType
             $params['domainid'],   // serviceId
             'synergywholesaledomains', // module
             'initiateAuCor', // moduleAction
-            'Initiate CoR Failed - ' . $e->getMessage(), // lastAttemptError
+            'Initiate CoR Failed - ' . $e->getMessage() // lastAttemptError
         );
         // Time to fail politely now
         return [

--- a/modules/registrars/synergywholesaledomains/synergywholesaledomains.php
+++ b/modules/registrars/synergywholesaledomains/synergywholesaledomains.php
@@ -2549,7 +2549,7 @@ function synergywholesaledomains_initiateAuCor(array $params)
             $params['domainid'],   // serviceId
             'synergywholesaledomains', // module
             'initiateAuCor', // moduleAction
-            'Initiate CoR Failed - ' . $e->getMessage() // lastAttemptError
+            $e->getMessage() // lastAttemptError
         );
         // Time to fail politely now
         return [

--- a/modules/registrars/synergywholesaledomains/synergywholesaledomains.php
+++ b/modules/registrars/synergywholesaledomains/synergywholesaledomains.php
@@ -3,7 +3,7 @@
 /**
  * Synergy Wholesale Registrar Module
  *
- * @copyright Copyright (c) Synergy Wholesale Pty Ltd 2020
+ * @copyright Copyright (c) Synergy Wholesale Pty Ltd
  * @license https://github.com/synergywholesale/whmcs-domains-module/LICENSE
  */
 
@@ -1610,8 +1610,9 @@ function synergywholesaledomains_initiateAuCorClient(array $params)
         if (array_key_exists($renewalLength, $vars['pricing'])) {
             $invoiceData = [
                 'userid' => $params['userid'],
-                'itemdescription1' => "Initiate CoR for {$params['domain']}",
+                'itemdescription1' => "Initiate CoR for {$params['domain']} - {$renewalLength} Year/s",
                 'itemamount1' => $vars['pricing'][$renewalLength]['renew'],
+                'itemtaxed1' => '1',
             ];
 
             $invoice = localAPI('CreateInvoice', $invoiceData);
@@ -1626,10 +1627,10 @@ function synergywholesaledomains_initiateAuCorClient(array $params)
                     'updated_at' => Carbon::now(),
                 ]);
             } else {
-                $errors[] = 'Failed to create invoice.';
+                $errors[] = 'Failed to create CoR Invoice.';
             }
         } else {
-            $errors[] = 'Selected renewal length is invalid.';
+            $errors[] = 'Selected registration length for CoR is invalid.';
         }
     }
 
@@ -2541,6 +2542,15 @@ function synergywholesaledomains_initiateAuCor(array $params)
             'domainName' => $domainInfo->domain ?? '',
         ], true);
     } catch (Exception $e) {
+        // Create item in Module Queue and then fail gracefully (as well)
+        WHMCS\Module\Queue::add(
+            'domain',  // serviceType
+            $params['domainid'],   // serviceId
+            'synergywholesaledomains', // module
+            'initiateAuCor', // moduleAction
+            'Initiate CoR Failed - ' . $e->getMessage(), // lastAttemptError
+        );
+        // Time to fail politely now
         return [
             'error' => $e->getMessage(),
         ];


### PR DESCRIPTION
Re: SYN-U1283847 (with SWS devs for 3+ months)

1. If CoR fails, add it to Module Queue so it isn't lost to space & time.
2. Make sure the CoR invoice line item is taxed to not throw books out.
3. Add "# Year/s" suffix to invoice line item, so it's more clear looking back.

Would appreciate if this could be tweaked/merged quickly, so we can stop thinking about it!

---

**Invoice Line Item**

<img width="500" alt="Screenshot 2025-02-11 at 6 19 27 PM" src="https://github.com/user-attachments/assets/c9bc1678-f1ad-458f-8325-9732363d1f1f" />

---

**Module Queue Entry**

<img width="861" alt="Screenshot 2025-02-11 at 6 18 05 PM" src="https://github.com/user-attachments/assets/f518f05b-1888-43ca-a4fa-a29e82546c14" />
