### PR TITLE
bugfix/SW-3755-dns-management-menu-broken-in-whmcs

### DIFF
--- a/modules/registrars/synergywholesaledomains/hooks.php
+++ b/modules/registrars/synergywholesaledomains/hooks.php
@@ -106,7 +106,7 @@ add_hook('ClientAreaPageDomainDNSManagement', 1, function (array $vars) {
     }
 
     if ('synergywholesaledomains' === $registrarModuleName) {
-        header("Location: clientarea.php?action=domaindetails&id={$domain_id}&modop=custom&a=manageDNSURLForwarding");
+        header("Location: clientarea.php?action=domaindetails&id={$domain_id}&modop=custom&a=manageDNSURLForwarding&token={$vars['token']}");
     }
 });
 


### PR DESCRIPTION
Due to the default WHMCS behaviour on custom menu item, it will fire a POST request including the CSRF token to access custom DNS Management page. However, when overriding the default DNS add-on built-in function, it redirect with a GET request not including the CSRF token, thus it logs the user out.

I have fixed this by appending the CSRF token to the redirect URL so it can bypass the validation.