### PR TITLE
bugfix/SW-3916-whmcs-request-logs-out-user-on-domain-module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ Synergy Wholesale WHMCS Domains Module
 ### Removed
 -
 
+## 2.5.7 [Updated 28/07/2025]
+
+### Fixed
+- CSRF missing from more ajax drop down menu's
+
 ## 2.5.6 [Updated 24/07/2025]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ Synergy Wholesale WHMCS Domains Module
 ### Fixed
 - CSRF missing from more ajax drop down menu's
 
+### Added
+- Resend approval email button on the admin service page
+
 ## 2.5.6 [Updated 24/07/2025]
 
 ### Fixed

--- a/modules/registrars/synergywholesaledomains/domainoptions.tpl
+++ b/modules/registrars/synergywholesaledomains/domainoptions.tpl
@@ -50,14 +50,14 @@
         {/if}
 
         {if $currentDnsConfigType == 2}
-            <p>To manage your Mail forwarding records, please visit the <a href="clientarea.php?action=domaindetails&id={$domainid}&modop=custom&a=manageEmailForwarding">Email Forwarding menu</a>.</p>
+            <p>To manage your Mail forwarding records, please visit the <a href="clientarea.php?action=domaindetails&id={$domainid}&modop=custom&a=manageEmailForwarding&token={$token}">Email Forwarding menu</a>.</p>
             {if $dnsmanagement == 1}
-                <p>To manage your DNS records or URL forwarding records, please visit the <a href="clientarea.php?action=domaindetails&id={$domainid}&modop=custom&a=manageDNSURLForwarding">DNS Management menu</a>.</p>
+                <p>To manage your DNS records or URL forwarding records, please visit the <a href="clientarea.php?action=domaindetails&id={$domainid}&modop=custom&a=manageDNSURLForwarding&token={$token}">DNS Management menu</a>.</p>
             {/if}
         {/if}
 
         {if $currentDnsConfigType == 4}
-            <p>To manage your DNS records, please visit the <a href="clientarea.php?action=domaindetails&id={$domainid}&modop=custom&a=manageDNSURLForwarding">DNS Management menu</a>.</p>
+            <p>To manage your DNS records, please visit the <a href="clientarea.php?action=domaindetails&id={$domainid}&modop=custom&a=manageDNSURLForwarding&token={$token}">DNS Management menu</a>.</p>
         {/if}
     </form>
     <br/>

--- a/modules/registrars/synergywholesaledomains/hooks.php
+++ b/modules/registrars/synergywholesaledomains/hooks.php
@@ -123,7 +123,7 @@ add_hook('ClientAreaPageDomainEmailForwarding', 1, function (array $vars) {
     }
 
     if ('synergywholesaledomains' === $registrarModuleName) {
-        header("Location: clientarea.php?action=domaindetails&id={$domain_id}&modop=custom&a=manageEmailForwarding");
+        header("Location: clientarea.php?action=domaindetails&id={$domain_id}&modop=custom&a=manageEmailForwarding&token={$vars['token']}");
     }
 });
 


### PR DESCRIPTION
More places have been found to logs users out every time they try to access a page which is generated by our module. This is mostly because of a link doesn't contain the CSRF token.

The following places have been spotted and fixed, and I believe this should be all of them:
- DNS Management menu item (My Domains > Select Domain > DNS Management)
- Addons - DNS Management (My Domains > Select Domain > Addons > DNS Host Record Management)
- Addons - Email Forwarding ( My Domains > Select Domain > Addons > Email Forwarding)
- Domain Options - Email Forwarding Menu (My Domains > Select Domain > Domain Options > Email Forwarding menu (link))
- Domain Options - DNS Management Menu (My Domains > Select Domain > Domain Options > DNS Management menu (link))